### PR TITLE
Set the default path on Linux to /home/user/

### DIFF
--- a/app/features/config/SelectWowDir.tsx
+++ b/app/features/config/SelectWowDir.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useState, SyntheticEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Snackbar, CircularProgress } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import { app, remote } from 'electron';
+import { remote } from 'electron';
+import { os } from 'os';
 import { setPath, selectPath } from './configSlice';
 import AddonManager from '../AddonsView/AddonManager/AddonManager';
 import { setAddons } from '../AddonsView/MyAddons/myAddonsSlice.ts';
@@ -18,7 +19,7 @@ function getDefaultPath() {
     return 'C:\\Program Files (x86)\\World of Warcraft\\_retail_';
   }
   if (os === 'linux') {
-    return app.getPath('home');
+    return os.homedir();
   }
   return '';
 }

--- a/app/features/config/SelectWowDir.tsx
+++ b/app/features/config/SelectWowDir.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState, SyntheticEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Snackbar, CircularProgress } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import { remote } from 'electron';
+import { app, remote } from 'electron';
 import { setPath, selectPath } from './configSlice';
 import AddonManager from '../AddonsView/AddonManager/AddonManager';
 import { setAddons } from '../AddonsView/MyAddons/myAddonsSlice.ts';
@@ -18,7 +18,7 @@ function getDefaultPath() {
     return 'C:\\Program Files (x86)\\World of Warcraft\\_retail_';
   }
   if (os === 'linux') {
-    return require('os').homedir();
+    return app.getPath('home');
   }
   return '';
 }

--- a/app/features/config/SelectWowDir.tsx
+++ b/app/features/config/SelectWowDir.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Button, Snackbar, CircularProgress } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import { remote } from 'electron';
-import { os } from 'os';
+import { homedir } from 'os';
 import { setPath, selectPath } from './configSlice';
 import AddonManager from '../AddonsView/AddonManager/AddonManager';
 import { setAddons } from '../AddonsView/MyAddons/myAddonsSlice.ts';
@@ -19,7 +19,7 @@ function getDefaultPath() {
     return 'C:\\Program Files (x86)\\World of Warcraft\\_retail_';
   }
   if (os === 'linux') {
-    return os.homedir();
+    return homedir();
   }
   return '';
 }

--- a/app/features/config/SelectWowDir.tsx
+++ b/app/features/config/SelectWowDir.tsx
@@ -17,6 +17,9 @@ function getDefaultPath() {
   if (os === 'win32') {
     return 'C:\\Program Files (x86)\\World of Warcraft\\_retail_';
   }
+  if (os === 'linux') {
+    return require('os').homedir();
+  }
   return '';
 }
 


### PR DESCRIPTION
Since Linux users have to play world of warcraft through wine
there really isn't a default path where wow would be installed.

starting in the home directory is a good default.